### PR TITLE
Allow setting env for 'mirrord ext' by prefixing 'MIRRORD_VSC_' in launch.json

### DIFF
--- a/changelog.d/+prefix-env.added.md
+++ b/changelog.d/+prefix-env.added.md
@@ -1,0 +1,1 @@
+Allow setting env for the agent by prefixing 'MIRRORD_VSC_' in launch.json for mirrord ext

--- a/changelog.d/+prefix-env.added.md
+++ b/changelog.d/+prefix-env.added.md
@@ -1,1 +1,1 @@
-Allow setting env for the agent by prefixing 'MIRRORD_VSC_' in launch.json for mirrord ext
+Allow setting env for `mirrord ext` by prefixing 'MIRRORD_VSC_' in launch.json.

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -79,7 +79,7 @@ export class ConfigurationProvider implements vscode.DebugConfigurationProvider 
 		}
 		setLastActiveMirrordPath(cliPath);
 
-		let mirrordApi = new MirrordAPI(cliPath);
+		let mirrordApi = new MirrordAPI(cliPath, config.env);
 
 		config.env ||= {};
 		let target = null;


### PR DESCRIPTION
While working on an issue, I was unable to set env like `MIRRORD_AGENT_RUST_LOG`, this patch prefixes such env and uses them for mirrord ext.